### PR TITLE
Add `BKDTreeInspector` and `IndexInspector`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'application'
 
 repositories {
   mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -29,5 +29,5 @@ dependencies {
 
 application {
   // Replace with your actual package and class name
-  mainClass = 'com.example.BKDTreeInspector'
+  mainClass = 'example.point.BKDTreeInspector'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,13 @@ def version = System.getProperty("lucene.version", "10.1.0")
 
 dependencies {
   implementation "org.apache.lucene:lucene-core:${version}"
+  implementation "org.apache.lucene:lucene-backward-codecs:${version}"
   implementation "org.apache.lucene:lucene-queries:${version}"
   implementation "org.apache.lucene:lucene-codecs:${version}"
   implementation "org.apache.lucene:lucene-sandbox:${version}"
 }
 
-application {
+/*application {
   // Replace with your actual package and class name
-  mainClass = 'example.point.BKDTreeInspector'
-}
+  mainClass = 'example.points.BKDTreeInspector'
+}*/

--- a/build.gradle
+++ b/build.gradle
@@ -25,3 +25,8 @@ dependencies {
   implementation "org.apache.lucene:lucene-codecs:${version}"
   implementation "org.apache.lucene:lucene-sandbox:${version}"
 }
+
+application {
+  // Replace with your actual package and class name
+  mainClass = 'com.example.BKDTreeInspector'
+}

--- a/src/main/java/example/basic/AnalyzeLogByteSizeMergePolicy.java
+++ b/src/main/java/example/basic/AnalyzeLogByteSizeMergePolicy.java
@@ -1,0 +1,225 @@
+package example.basic;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MergePolicy;
+import org.apache.lucene.index.LogByteSizeMergePolicy;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * This test simulates continuous indexing over time, where newer documents have newer timestamps.
+ * It demonstrates how segment creation correlates with timestamp ordering in a real-world scenario.
+ */
+public class AnalyzeLogByteSizeMergePolicy {
+
+    private static final String TIMESTAMP_FIELD = "timestamp";
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+    public static void main(String[] args) throws IOException {
+        // Create a temporary directory for the index
+        Path indexPath = Files.createTempDirectory("lucene-continuous-indexing-test");
+        System.out.println("Index path: " + indexPath);
+
+        try {
+            Directory directory = FSDirectory.open(indexPath);
+            MergePolicy mergePolicy = new LogByteSizeMergePolicy();
+
+            // Simulate continuous indexing over several "days"
+            simulateContinuousIndexing(directory, mergePolicy);
+
+            // Examine the index after continuous indexing
+            System.out.println("\n=== Index after continuous indexing ===");
+            examineIndex(directory);
+
+            // Force merge to 1 segment
+            forceMergeIndex(directory, mergePolicy, 1);
+
+            // Examine after force merge
+            System.out.println("\n=== Index after force merge to 1 segment ===");
+            examineIndex(directory);
+
+            // Close resources
+            directory.close();
+        } catch (Exception e) {
+            System.err.println("Error during test: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Simulates continuous indexing over time, where each "day" of indexing adds
+     * newer documents with increasing timestamps.
+     */
+    private static void simulateContinuousIndexing(Directory directory, MergePolicy mergePolicy) throws IOException {
+        System.out.println("\n=== Simulating continuous indexing over time ===");
+
+        // Base timestamp for our simulation (start from now)
+        long baseTimestamp = System.currentTimeMillis();
+
+        // Create a writer with the merge policy
+        IndexWriterConfig config = new IndexWriterConfig();
+        config.setMergePolicy(mergePolicy);
+
+        // We'll use a moderate buffer size to allow some natural segment formation
+        config.setMaxBufferedDocs(50);
+
+        try (IndexWriter writer = new IndexWriter(directory, config)) {
+            // Simulate 5 "days" of indexing
+            for (int day = 0; day < 5; day++) {
+                System.out.println("Indexing day " + day + "...");
+
+                // Each "day" we add 100 documents with increasing timestamps
+                for (int docInDay = 0; docInDay < 100; docInDay++) {
+                    // Calculate a timestamp that increases with each document
+                    // Each "day" is offset by 24 hours (86400000 ms)
+                    long timestamp = baseTimestamp + (day * 86400000) + (docInDay * 60000); // Each doc is 1 minute apart
+
+                    Document doc = new Document();
+                    doc.add(new StringField("day", "day" + day, Field.Store.YES));
+                    doc.add(new StringField("docInDay", String.valueOf(docInDay), Field.Store.YES));
+                    doc.add(new LongPoint(TIMESTAMP_FIELD, timestamp));
+                    doc.add(new NumericDocValuesField(TIMESTAMP_FIELD, timestamp));
+                    doc.add(new StoredField(TIMESTAMP_FIELD, timestamp));
+
+                    writer.addDocument(doc);
+
+                    // Commit every 20 documents to force some segment creation
+                    if (docInDay > 0 && docInDay % 20 == 0) {
+                        writer.commit();
+                        System.out.println("  Committed batch " + (docInDay / 20) + " of day " + day);
+                    }
+                }
+
+                // Always commit at the end of each "day"
+                writer.commit();
+                System.out.println("  Completed indexing for day " + day);
+
+                // Print segment count at this point
+                try (IndexReader reader = DirectoryReader.open(directory)) {
+                    System.out.println("  Number of segments after day " + day + ": " + reader.leaves().size());
+                }
+            }
+        }
+    }
+
+    private static void forceMergeIndex(Directory directory, MergePolicy mergePolicy, int maxSegments) throws IOException {
+        IndexWriterConfig config = new IndexWriterConfig();
+        config.setMergePolicy(mergePolicy);
+
+        try (IndexWriter writer = new IndexWriter(directory, config)) {
+            System.out.println("Force merging to " + maxSegments + " segments...");
+            writer.forceMerge(maxSegments);
+        }
+    }
+
+    private static void examineIndex(Directory directory) throws IOException {
+        try (IndexReader reader = DirectoryReader.open(directory)) {
+            System.out.println("Number of segments: " + reader.leaves().size());
+
+            int segmentNum = 0;
+            for (LeafReaderContext leafContext : reader.leaves()) {
+                System.out.println("\n--- Segment " + segmentNum + " ---");
+                System.out.println("Document count: " + leafContext.reader().maxDoc());
+
+                // Check timestamp range for this segment
+                analyzeSegmentTimestampRange(leafContext, TIMESTAMP_FIELD);
+
+                // Show sample documents from beginning, middle and end of segment
+                sampleDocuments(leafContext, TIMESTAMP_FIELD);
+
+                segmentNum++;
+            }
+        }
+    }
+
+    private static void analyzeSegmentTimestampRange(LeafReaderContext leafContext, String field) throws IOException {
+        NumericDocValues docValues = leafContext.reader().getNumericDocValues(field);
+        if (docValues == null) {
+            System.out.println("No numeric doc values for field: " + field);
+            return;
+        }
+
+        long minTimestamp = Long.MAX_VALUE;
+        long maxTimestamp = Long.MIN_VALUE;
+        String minDay = "";
+        String maxDay = "";
+
+        // Find min and max timestamps in this segment
+        for (int i = 0; i < leafContext.reader().maxDoc(); i++) {
+            if (docValues.advanceExact(i)) {
+                long timestamp = docValues.longValue();
+                Document doc = leafContext.reader().storedFields().document(i);
+
+                if (timestamp < minTimestamp) {
+                    minTimestamp = timestamp;
+                    minDay = doc.get("day");
+                }
+
+                if (timestamp > maxTimestamp) {
+                    maxTimestamp = timestamp;
+                    maxDay = doc.get("day");
+                }
+            }
+        }
+
+        if (minTimestamp != Long.MAX_VALUE && maxTimestamp != Long.MIN_VALUE) {
+            System.out.println("Timestamp range:");
+            System.out.println("  Min: " + minTimestamp + " (" + DATE_FORMAT.format(new Date(minTimestamp)) + ") from " + minDay);
+            System.out.println("  Max: " + maxTimestamp + " (" + DATE_FORMAT.format(new Date(maxTimestamp)) + ") from " + maxDay);
+            System.out.println("  Time span: " + ((maxTimestamp - minTimestamp) / (60 * 1000)) + " minutes");
+        } else {
+            System.out.println("No timestamp values found in this segment");
+        }
+    }
+
+    private static void sampleDocuments(LeafReaderContext leafContext, String field) throws IOException {
+        int maxDoc = leafContext.reader().maxDoc();
+        if (maxDoc == 0) return;
+
+        System.out.println("\nAll documents in this segment:");
+        System.out.println("DocID | Timestamp | Date");
+        System.out.println("----------------------------------------------");
+
+        NumericDocValues docValues = leafContext.reader().getNumericDocValues(field);
+        if (docValues == null) {
+            System.out.println("No numeric doc values for field: " + field);
+            return;
+        }
+
+        // Print all documents (limited to first 500 to avoid excessive output)
+        int limit = Math.min(500, maxDoc);
+        for (int position = 0; position < limit; position++) {
+            if (docValues.advanceExact(position)) {
+                long timestamp = docValues.longValue();
+                String date = DATE_FORMAT.format(new Date(timestamp));
+
+                System.out.printf("%5d | %d | %s%n",
+                        position, timestamp, date);
+            } else {
+                System.out.printf("%5d | No timestamp value%n", position);
+            }
+        }
+
+        // If we hit the limit, show that there are more docs
+        if (maxDoc > limit) {
+            System.out.println("... " + (maxDoc - limit) + " more documents not shown ...");
+        }
+    }
+}

--- a/src/main/java/example/basic/IndexInspector.java
+++ b/src/main/java/example/basic/IndexInspector.java
@@ -1,0 +1,169 @@
+package example.basic;
+
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.store.FSDirectory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+public class IndexInspector {
+
+    public static void main(String[] args) throws Exception {
+        // Path for the index that has regression issues
+        Path indexPathWithRegression = Paths.get("/home/ec2-user/OS_30/OS_30_27_Vanilla_968eafbd37ef0b864e887643c74291cc3e5ca0d0/nodes/0/indices/rOA5QvdyQ-2JYf3h0WZmFw/0/index");
+        // Path indexPathWithoutRegression = Paths.get("/home/ec2-user/OS_30/OS_2191_1_2e4741fb45d1b150aaeeadf66d41445b23ff5982/nodes/0/indices/Id-ddMW1RTqSkiHeqTbCRA/0/index");
+        String fieldName = "@timestamp";
+        System.out.println("\n\n=== INSPECTING INDEX WITH REGRESSION ===");
+        inspectIndex(indexPathWithRegression, fieldName);
+    }
+
+    private static void inspectIndex(Path indexPath, String fieldName) throws IOException {
+
+        try (FSDirectory directory = FSDirectory.open(indexPath);
+             IndexReader reader = DirectoryReader.open(directory)) {
+
+            for (LeafReaderContext leaf : reader.leaves()) {
+                System.out.println("\n--- Document Order Analysis ---");
+                printDocumentsInOrder(leaf, fieldName);
+
+                System.out.println("\n--- listAvailableFields ---");
+                listAvailableFields(leaf);
+
+                System.out.println("\n--- listPointValueFields ---");
+                listPointValueFields(leaf);
+
+                System.out.println("\n--- listDocValueFields ---");
+                listDocValueFields(leaf);
+            }
+        }
+    }
+
+    // New method to print documents in order of their timestamp values
+    private static void printDocumentsInOrder(LeafReaderContext leaf, String fieldName) throws IOException {
+
+        // First check if this field exists
+        FieldInfo fieldInfo = leaf.reader().getFieldInfos().fieldInfo(fieldName);
+        if (fieldInfo == null) {
+            System.out.println("Field '" + fieldName + "' does not exist in this segment");
+            return;
+        }
+
+        SortedNumericDocValues docValues = leaf.reader().getSortedNumericDocValues(fieldName);
+        if (docValues == null) {
+            System.out.println("No sorted numeric doc values for field '" + fieldName + "'");
+            return;
+        }
+
+        // Collect all documents and their timestamp values
+        List<DocTimestamp> docTimestamps = new ArrayList<>();
+
+        // Iterate through all docs that have this field
+        int docId;
+        while ((docId = docValues.nextDoc()) != DocIdSetIterator.NO_MORE_DOCS) {
+            // SortedNumericDocValues may have multiple values per document
+            // For timestamp we typically take the first one
+            if (docValues.docValueCount() > 0) {
+                long timestamp = docValues.nextValue();
+                docTimestamps.add(new DocTimestamp(docId, timestamp));
+            }
+        }
+
+        // Print number of documents found
+        System.out.println("Found " + docTimestamps.size() + " documents with timestamp values");
+
+        if (docTimestamps.isEmpty()) {
+            return;
+        }
+
+        // Sort by document ID to see physical order
+        List<DocTimestamp> byDocId = new ArrayList<>(docTimestamps);
+        Collections.sort(byDocId, Comparator.comparingInt(DocTimestamp::getDocId));
+
+        // Sort by timestamp descending to see logical order
+        List<DocTimestamp> byTimestamp = new ArrayList<>(docTimestamps);
+        Collections.sort(byTimestamp, Comparator.comparingLong(DocTimestamp::getTimestamp).reversed());
+
+        // Print the first 100 documents by document ID
+        System.out.println("\nFirst 100 documents by document ID (physical order):");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
+        int limit = Math.min(100, byDocId.size());
+        for (int i = 0; i < limit; i++) {
+            DocTimestamp dt = byDocId.get(i);
+            System.out.printf("DocID: %d, Timestamp: %d (%s)%n",
+                    dt.getDocId(),
+                    dt.getTimestamp(),
+                    sdf.format(new Date(dt.getTimestamp())));
+        }
+    }
+
+    // Helper class to store document ID and timestamp together
+    private static class DocTimestamp {
+        private final int docId;
+        private final long timestamp;
+
+        public DocTimestamp(int docId, long timestamp) {
+            this.docId = docId;
+            this.timestamp = timestamp;
+        }
+
+        public int getDocId() {
+            return docId;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+    }
+
+    private static void listAvailableFields(LeafReaderContext leaf) throws IOException {
+        System.out.println("Available fields in segment:");
+        FieldInfos fieldInfos = leaf.reader().getFieldInfos();
+        for (int i = 0; i < fieldInfos.size(); i++) {
+            FieldInfo fieldInfo = fieldInfos.fieldInfo(i);
+            String field = fieldInfo.name;
+
+            // Check if it has point values
+            boolean hasPointValues = fieldInfo.getPointDimensionCount() > 0;
+
+            // Check if it has doc values
+            boolean hasDocValues = fieldInfo.getDocValuesType() != DocValuesType.NONE;
+
+            System.out.printf(" - %s (points: %s, docValues: %s)%n",
+                    field, hasPointValues, hasDocValues);
+        }
+    }
+
+    private static void listPointValueFields(LeafReaderContext leaf) throws IOException {
+        System.out.println("Available point value fields in segment:");
+        FieldInfos fieldInfos = leaf.reader().getFieldInfos();
+        for (int i = 0; i < fieldInfos.size(); i++) {
+            FieldInfo fieldInfo = fieldInfos.fieldInfo(i);
+            if (fieldInfo.getPointDimensionCount() > 0) {
+                System.out.println(" - " + fieldInfo.name +
+                        " (dims: " + fieldInfo.getPointDimensionCount() +
+                        ", numBytes: " + fieldInfo.getPointNumBytes() + ")");
+            }
+        }
+    }
+
+    private static void listDocValueFields(LeafReaderContext leaf) throws IOException {
+        System.out.println("Available doc value fields in segment:");
+        FieldInfos fieldInfos = leaf.reader().getFieldInfos();
+        for (int i = 0; i < fieldInfos.size(); i++) {
+            FieldInfo fieldInfo = fieldInfos.fieldInfo(i);
+            if (fieldInfo.getDocValuesType() != DocValuesType.NONE) {
+                System.out.println(" - " + fieldInfo.name +
+                        " (type: " + fieldInfo.getDocValuesType() + ")");
+            }
+        }
+    }
+}

--- a/src/main/java/example/points/BKDTreeInspector.java
+++ b/src/main/java/example/points/BKDTreeInspector.java
@@ -1,102 +1,208 @@
 package example.points;
 
-import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.PointValues;
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TotalHitCountCollectorManager;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.index.*;
 import org.apache.lucene.store.FSDirectory;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 public class BKDTreeInspector {
 
     public static void main(String[] args) throws Exception {
-        // Adjust the path below to point to your index directory.
-        Path indexPath = Paths.get("/home/ec2-user/OS_30/OS_30_1_968eafbd37ef0b864e887643c74291cc3e5ca0d0/nodes/0/indices/rOA5QvdyQ-2JYf3h0WZmFw/0/index/");
+        // Path for the index that has regression issues
+        Path indexPathWithRegression = Paths.get("/home/ec2-user/OS_30/OS_30_27_Vanilla_968eafbd37ef0b864e887643c74291cc3e5ca0d0/nodes/0/indices/rOA5QvdyQ-2JYf3h0WZmFw/0/index");
+        // Path indexPathWithoutRegression = Paths.get("/home/ec2-user/OS_30/OS_2191_1_2e4741fb45d1b150aaeeadf66d41445b23ff5982/nodes/0/indices/Id-ddMW1RTqSkiHeqTbCRA/0/index");
+        String fieldName = "@timestamp";
+        System.out.println("\n\n=== INSPECTING INDEX WITH REGRESSION ===");
+        inspectIndex(indexPathWithRegression, fieldName);
+    }
+
+    private static void inspectIndex(Path indexPath, String fieldName) throws IOException {
+        System.out.println("Inspecting BKD tree for path: " + indexPath);
+        System.out.println("Field name: " + fieldName);
+
         try (FSDirectory directory = FSDirectory.open(indexPath);
              IndexReader reader = DirectoryReader.open(directory)) {
 
-            IndexSearcher searcher = new IndexSearcher(reader);
-
-            // Run a range query over the "val" field in the range [2000,3999].
-            Query query = IntPoint.newRangeQuery("val", 2000, 3999);
-            int count = searcher.search(query, new TotalHitCountCollectorManager(searcher.getSlices()));
-            System.out.println("Range query " + query + " matched " + count + " documents");
-
-            // Now traverse the BKD tree for field "val" in each leaf (or partition)
             for (LeafReaderContext leaf : reader.leaves()) {
-                PointValues pv = leaf.reader().getPointValues("val");
-                if (pv != null) {
-                    System.out.println("\n--- BKD tree for leaf: " + leaf + " ---");
-                    PointValues.PointTree tree = pv.getPointTree();
-                    dumpBKD(tree, 0);
-                } else {
-                    System.out.println("Leaf " + leaf + " has no point values for field 'val'.");
+                PointValues pointValues = leaf.reader().getPointValues(fieldName);
+                if (pointValues == null) {
+                    System.out.println("No point values for field '" + fieldName + "' in leaf: " + leaf);
+                    continue;
                 }
+
+                System.out.println("\n=== Leaf: " + leaf + " ===");
+                System.out.println("Total points: " + pointValues.size());
+                System.out.println("Doc count: " + pointValues.getDocCount());
+
+                // Calculate points per doc ratio
+                double pointsPerDoc = (double) pointValues.size() / pointValues.getDocCount();
+                System.out.println("Points per doc ratio: " + pointsPerDoc);
+
+                // Analyze the min/max range
+                byte[] minPackedValue = pointValues.getMinPackedValue();
+                byte[] maxPackedValue = pointValues.getMaxPackedValue();
+
+                long minTimestamp = LongPoint.decodeDimension(minPackedValue, 0);
+                long maxTimestamp = LongPoint.decodeDimension(maxPackedValue, 0);
+
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+                System.out.println("Min timestamp: " + minTimestamp + " (" + sdf.format(new Date(minTimestamp)) + ")");
+                System.out.println("Max timestamp: " + maxTimestamp + " (" + sdf.format(new Date(maxTimestamp)) + ")");
+                System.out.println("Range span: " + (maxTimestamp - minTimestamp) + " ms");
+
+                // Analyze BKD tree structure
+                analyzeBKDTree(pointValues);
+
             }
         }
     }
 
-    /**
-     * Recursively dumps the BKD tree structure.
-     *
-     * @param tree  The current BKD tree node.
-     * @param level The current depth (for indentation).
-     */
-    private static void dumpBKD(PointValues.PointTree tree, int level) throws IOException {
-        String indent = " ".repeat(level * 2);
-        byte[] minPackedValue = tree.getMinPackedValue();
-        byte[] maxPackedValue = tree.getMaxPackedValue();
-        System.out.println(indent + "Node at level " + level);
-        System.out.println(indent + "  Min value: " + decodeValue(minPackedValue));
-        System.out.println(indent + "  Max value: " + decodeValue(maxPackedValue));
 
-        // If we can move to a child, this node is internal.
+    private static void analyzeBKDTree(PointValues pointValues) throws IOException {
+        PointValues.PointTree tree = pointValues.getPointTree();
+
+        // Basic tree info
+        int treeDepth = measureTreeDepth(tree.clone());
+        System.out.println("\nBKD Tree Analysis:");
+        System.out.println("Tree depth: " + treeDepth);
+
+        // Calculate theoretical leaf nodes
+        int maxLeaves = 1 << treeDepth;
+        System.out.println("Max theoretical leaves: " + maxLeaves);
+
+        // Count actual leaf nodes and analyze their balance
+        LeafNodeStats stats = countLeafNodes(tree.clone(), 1, 0);
+        System.out.println("Actual leaf nodes: " + stats.leafCount);
+        System.out.println("Leaf node imbalance: " + (maxLeaves - stats.leafCount) + " missing leaves");
+        System.out.println("Min leaf size: " + stats.minSize);
+        System.out.println("Max leaf size: " + stats.maxSize);
+        System.out.println("Avg leaf size: " + (stats.totalPoints / (double)stats.leafCount));
+        System.out.println("Size ratio (max/min): " + (stats.minSize > 0 ? stats.maxSize / (double)stats.minSize : "N/A"));
+
+        // Analyze node distribution per level
+        Map<Integer, int[]> levelStats = new HashMap<>();
+        collectLevelStats(tree.clone(), 1, 0, levelStats);
+
+        System.out.println("\nLevel distribution:");
+        for (int level = 0; level <= treeDepth; level++) {
+            int[] stats2 = levelStats.getOrDefault(level, new int[]{0, 0});
+            int nodeCount = stats2[0];
+            long totalSize = stats2[1];
+            double avgSize = nodeCount > 0 ? totalSize / (double)nodeCount : 0;
+
+            System.out.printf("Level %d: %d nodes, avg size: %.2f%n",
+                    level, nodeCount, avgSize);
+        }
+
+        // Analyze split value distribution - critical for understanding BKD tree balance
+        System.out.println("\nLevel split values (sampling):");
+        analyzeSplitValues(tree.clone(), 1, 0);
+    }
+
+    private static class LeafNodeStats {
+        int leafCount = 0;
+        long minSize = Long.MAX_VALUE;
+        long maxSize = 0;
+        long totalPoints = 0;
+    }
+
+    private static LeafNodeStats countLeafNodes(PointValues.PointTree tree, int nodeID, int level) throws IOException {
+        LeafNodeStats stats = new LeafNodeStats();
+
+        if (!tree.moveToChild()) {
+            // This is a leaf node
+            stats.leafCount = 1;
+            long size = tree.size();
+            stats.minSize = size;
+            stats.maxSize = size;
+            stats.totalPoints = size;
+            return stats;
+        }
+
+        // Internal node - process children
+        do {
+            LeafNodeStats childStats = countLeafNodes(tree.clone(), nodeID * 2 + (tree.moveToSibling() ? 1 : 0), level + 1);
+            stats.leafCount += childStats.leafCount;
+            stats.minSize = Math.min(stats.minSize, childStats.minSize);
+            stats.maxSize = Math.max(stats.maxSize, childStats.maxSize);
+            stats.totalPoints += childStats.totalPoints;
+        } while (tree.moveToSibling());
+
+        return stats;
+    }
+
+    private static void collectLevelStats(PointValues.PointTree tree, int nodeID, int level, Map<Integer, int[]> levelStats) throws IOException {
+        // Record this node's stats
+        int[] stats = levelStats.computeIfAbsent(level, k -> new int[2]);
+        stats[0]++; // increment node count
+        stats[1] += tree.size(); // add size
+
+        // Process children if this is not a leaf
         if (tree.moveToChild()) {
             do {
-                dumpBKD(tree, level + 1);
+                collectLevelStats(tree.clone(), nodeID * 2 + (tree.moveToSibling() ? 1 : 0), level + 1, levelStats);
             } while (tree.moveToSibling());
             tree.moveToParent();
-        } else {
-            // Leaf node: iterate over each document in this leaf.
-            System.out.println(indent + "  Leaf node docs:");
-            tree.visitDocValues(new PointValues.IntersectVisitor() {
-                @Override
-                public void visit(int docID, byte[] packedValue) throws IOException {
-                    int val = IntPoint.decodeDimension(packedValue, 0);
-                    System.out.println("Leaf docID: " + docID + ", value: " + val);
-                }
-
-                @Override
-                public void visit(int docID) throws IOException {
-                    // Called when an entire cell is inside the query.
-                    System.out.println("Leaf docID: " + docID + " (full cell)");
-                }
-
-                @Override
-                public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
-                    // For our dumping purpose, we simply return CELL_INSIDE_QUERY to ensure we visit every doc.
-                    return PointValues.Relation.CELL_INSIDE_QUERY;
-                }
-            });
-
         }
     }
 
-    /**
-     * Decodes a single-dimensional int value from a packed value.
-     *
-     * @param packedValue The packed byte array.
-     * @return The decoded integer.
-     */
-    private static int decodeValue(byte[] packedValue) {
-        return IntPoint.decodeDimension(packedValue, 0);
+    private static void analyzeSplitValues(PointValues.PointTree tree, int nodeID, int level) throws IOException {
+        if (level > 5) return; // Limit depth to avoid too much output
+
+        byte[] minValue = tree.getMinPackedValue();
+        byte[] maxValue = tree.getMaxPackedValue();
+        long minTimestamp = LongPoint.decodeDimension(minValue, 0);
+        long maxTimestamp = LongPoint.decodeDimension(maxValue, 0);
+
+        System.out.printf("Node %d (Level %d): Range [%d to %d], Size: %d%n",
+                nodeID, level, minTimestamp, maxTimestamp, tree.size());
+
+        if (tree.moveToChild()) {
+            // Get left child's max value to determine split point
+            PointValues.PointTree leftChild = tree.clone();
+            byte[] leftChildMax = leftChild.getMaxPackedValue();
+            long splitValue = LongPoint.decodeDimension(leftChildMax, 0);
+
+            System.out.printf("  Split value: %d%n", splitValue);
+
+            // Calculate split ratio - critical for understanding imbalance
+            long leftRange = splitValue - minTimestamp;
+            long rightRange = maxTimestamp - splitValue;
+            long totalRange = maxTimestamp - minTimestamp;
+
+            if (totalRange > 0) {
+                double leftRatio = leftRange / (double)totalRange;
+                double rightRatio = rightRange / (double)totalRange;
+                System.out.printf("  Split ratios: left=%.2f, right=%.2f%n", leftRatio, rightRatio);
+            }
+
+            // Recurse to children
+            analyzeSplitValues(leftChild, nodeID * 2, level + 1);
+
+            if (tree.moveToSibling()) {
+                analyzeSplitValues(tree.clone(), nodeID * 2 + 1, level + 1);
+            }
+        }
+    }
+
+    private static int measureTreeDepth(PointValues.PointTree tree) throws IOException {
+        if (!tree.moveToChild()) {
+            return 0; // Leaf node
+        }
+
+        int maxDepth = 0;
+        do {
+            int childDepth = measureTreeDepth(tree.clone());
+            maxDepth = Math.max(maxDepth, childDepth);
+        } while (tree.moveToSibling());
+
+        return maxDepth + 1;
     }
 }

--- a/src/main/java/example/points/BKDTreeInspector.java
+++ b/src/main/java/example/points/BKDTreeInspector.java
@@ -1,0 +1,102 @@
+package example.points;
+
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TotalHitCountCollectorManager;
+import org.apache.lucene.store.FSDirectory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class BKDTreeInspector {
+
+    public static void main(String[] args) throws Exception {
+        // Adjust the path below to point to your index directory.
+        Path indexPath = Paths.get("OS_30_1_968eafbd37ef0b864e887643c74291cc3e5ca0d0/nodes/0/indices/rOA5QvdyQ-2JYf3h0WZmFw/0/index/");
+        try (FSDirectory directory = FSDirectory.open(indexPath);
+             IndexReader reader = DirectoryReader.open(directory)) {
+
+            IndexSearcher searcher = new IndexSearcher(reader);
+
+            // Run a range query over the "val" field in the range [2000,3999].
+            Query query = IntPoint.newRangeQuery("val", 2000, 3999);
+            int count = searcher.search(query, new TotalHitCountCollectorManager(searcher.getSlices()));
+            System.out.println("Range query " + query + " matched " + count + " documents");
+
+            // Now traverse the BKD tree for field "val" in each leaf (or partition)
+            for (LeafReaderContext leaf : reader.leaves()) {
+                PointValues pv = leaf.reader().getPointValues("val");
+                if (pv != null) {
+                    System.out.println("\n--- BKD tree for leaf: " + leaf + " ---");
+                    PointValues.PointTree tree = pv.getPointTree();
+                    dumpBKD(tree, 0);
+                } else {
+                    System.out.println("Leaf " + leaf + " has no point values for field 'val'.");
+                }
+            }
+        }
+    }
+
+    /**
+     * Recursively dumps the BKD tree structure.
+     *
+     * @param tree  The current BKD tree node.
+     * @param level The current depth (for indentation).
+     */
+    private static void dumpBKD(PointValues.PointTree tree, int level) throws IOException {
+        String indent = " ".repeat(level * 2);
+        byte[] minPackedValue = tree.getMinPackedValue();
+        byte[] maxPackedValue = tree.getMaxPackedValue();
+        System.out.println(indent + "Node at level " + level);
+        System.out.println(indent + "  Min value: " + decodeValue(minPackedValue));
+        System.out.println(indent + "  Max value: " + decodeValue(maxPackedValue));
+
+        // If we can move to a child, this node is internal.
+        if (tree.moveToChild()) {
+            do {
+                dumpBKD(tree, level + 1);
+            } while (tree.moveToSibling());
+            tree.moveToParent();
+        } else {
+            // Leaf node: iterate over each document in this leaf.
+            System.out.println(indent + "  Leaf node docs:");
+            tree.visitDocValues(new PointValues.IntersectVisitor() {
+                @Override
+                public void visit(int docID, byte[] packedValue) throws IOException {
+                    int val = IntPoint.decodeDimension(packedValue, 0);
+                    System.out.println("Leaf docID: " + docID + ", value: " + val);
+                }
+
+                @Override
+                public void visit(int docID) throws IOException {
+                    // Called when an entire cell is inside the query.
+                    System.out.println("Leaf docID: " + docID + " (full cell)");
+                }
+
+                @Override
+                public PointValues.Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+                    // For our dumping purpose, we simply return CELL_INSIDE_QUERY to ensure we visit every doc.
+                    return PointValues.Relation.CELL_INSIDE_QUERY;
+                }
+            });
+
+        }
+    }
+
+    /**
+     * Decodes a single-dimensional int value from a packed value.
+     *
+     * @param packedValue The packed byte array.
+     * @return The decoded integer.
+     */
+    private static int decodeValue(byte[] packedValue) {
+        return IntPoint.decodeDimension(packedValue, 0);
+    }
+}

--- a/src/main/java/example/points/BKDTreeInspector.java
+++ b/src/main/java/example/points/BKDTreeInspector.java
@@ -19,7 +19,7 @@ public class BKDTreeInspector {
 
     public static void main(String[] args) throws Exception {
         // Adjust the path below to point to your index directory.
-        Path indexPath = Paths.get("OS_30_1_968eafbd37ef0b864e887643c74291cc3e5ca0d0/nodes/0/indices/rOA5QvdyQ-2JYf3h0WZmFw/0/index/");
+        Path indexPath = Paths.get("/home/ec2-user/OS_30/OS_30_1_968eafbd37ef0b864e887643c74291cc3e5ca0d0/nodes/0/indices/rOA5QvdyQ-2JYf3h0WZmFw/0/index/");
         try (FSDirectory directory = FSDirectory.open(indexPath);
              IndexReader reader = DirectoryReader.open(directory)) {
 


### PR DESCRIPTION
While debugging the performance issue in OpenSearch 3.0.0 ([opensearch-project/OpenSearch#17404](https://github.com/opensearch-project/OpenSearch/issues/17404)), it became necessary for me to understand how documents are physically ordered within segments, how timestamp-based indexing affects segment formation and BKD tree structure. This PR introduces `BKDTreeInspector` and `IndexInspector` that can run on the index data directory and displays important information.